### PR TITLE
Remove lexical-binding setting

### DIFF
--- a/smart-cursor-color.el
+++ b/smart-cursor-color.el
@@ -1,4 +1,4 @@
-;;; smart-cursor-color.el --- Change cursor color dynamically. -*- lexical-binding: t -*-
+;;; smart-cursor-color.el --- Change cursor color dynamically
 ;;
 ;; Filename: smart-cursor-color.el
 ;; Description: Change cursor color dynamically at cursor or pointer.


### PR DESCRIPTION
This setting implies that Emacs 24 is required, which is not the case here.
